### PR TITLE
Refactor methods to use LocalLibrarySettings object

### DIFF
--- a/LocalLibrary.cs
+++ b/LocalLibrary.cs
@@ -97,7 +97,7 @@ namespace LocalLibrary
                 var ignorelist = Settings.Settings.RegexList.Select(item => new MergedItem { Value = item, Source = "Regex" })
                     .Concat(Settings.Settings.StringList.Select(item => new MergedItem { Value = item, Source = "String" }))
                     .ToList();
-                addedGames = addGames.FindInstallers(installPaths.ToList(), Settings.Settings.UseActions, Settings.Settings.Levenshtein, Settings.Settings.SelectedSources, Settings.Settings.SelectedPlatform, ignorelist, Settings.Settings.FindUpdates);
+                addedGames = addGames.FindInstallers(installPaths.ToList(), Settings.Settings, ignorelist);
             }
             return addedGames;
         }
@@ -256,10 +256,9 @@ namespace LocalLibrary
             string[] scripts = { ".bat", ".ps1", ".ps" };
             bool archive = false;
             bool redirect = false;
-            bool actions = Settings.Settings.UseActions;
             Finder finder = new Finder();
 
-            var results = finder.GetActionsRoms(game, actions);
+            var results = finder.GetActionsRoms(game, Settings.Settings);
             string gameImagePath = results.Item1;
             string gameInstallArgs = results.Item2;
             List<Dictionary<string, string>> extras = results.Item3;

--- a/LocalLibrarySettingsView.xaml.cs
+++ b/LocalLibrarySettingsView.xaml.cs
@@ -28,6 +28,7 @@ namespace LocalLibrary
         public void Button_AddGames_Click(object sender, RoutedEventArgs e)
         {
             Finder addGames = new Finder();
+            
             List<string> installPaths = PathsBox.Items.Cast<string>().ToList();
 
             if (installPaths == null || !installPaths.Any())
@@ -66,7 +67,11 @@ namespace LocalLibrary
             var ignorelist = RegexList.Items.Cast<string>().Select(item => new MergedItem { Value = item, Source = "Regex" })
                 .Concat(StringList.Items.Cast<string>().Select(item => new MergedItem { Value = item, Source = "String" }))
                 .ToList();
-            addGames.FindInstallers(installPaths, useActions, levenValue, sources, platform, ignorelist, cbFindUpdates.IsChecked ?? false);
+            if (DataContext is LocalLibrarySettingsViewModel viewModel)
+            {
+                addGames.FindInstallers(installPaths, viewModel.Settings, ignorelist);
+            }
+            
         }
 
         public void Button_ArchiveBrowse_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Refactor methods to use LocalLibrarySettings object

Updated `GetActionsRoms` and `FindInstallers` methods to accept a `LocalLibrarySettings` object, enhancing configuration flexibility. Modified file existence checks to include extension validation and refactored game update logic to conditionally execute based on settings. Ensured consistent usage of settings across the application in relevant methods.