### PR TITLE
Refactor conditional logic in FindInstallers.cs

### DIFF
--- a/FindInstallers.cs
+++ b/FindInstallers.cs
@@ -146,11 +146,11 @@ namespace LocalLibrary
                     }
                     else
                     {
-                        logger.Info($"GetMainInstaller({dir}) - No preferred installer name found for file: {file}");
+                        logger.Info($"GetMainInstaller({dir}) - {file} is not a preferred filename.");
                     }
                 }
                 
-                else if (validExt.Contains(Path.GetExtension(file), StringComparer.OrdinalIgnoreCase))
+                if (validExt.Contains(Path.GetExtension(file), StringComparer.OrdinalIgnoreCase))
                 {
                     logger.Info($"GetMainInstaller({dir}) - Found valid extension: {Path.GetExtension(file)} for file: {file}");
                     gameInstaller = file;


### PR DESCRIPTION
Refactor conditional logic in FindInstallers.cs

Removed an `else` statement and replaced it with an `if` statement to allow independent checking of valid file extensions.  This solves the case of installers using a preferred extension, but without using 'install' or 'setup' in the name.